### PR TITLE
Migration to Asp.Net Core 3.0 and Blazor 0.8.0

### DIFF
--- a/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
+++ b/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="3.0.0-preview-19075-0444" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/BlazorSignalR/BlazorSignalR.csproj
+++ b/src/BlazorSignalR/BlazorSignalR.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <Title>Blazor SignalR</Title>
@@ -12,9 +12,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="1.0.4" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.8.0-preview-19104-04" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="3.0.0-preview-19075-0444" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0-preview-19075-0444" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0-preview.19074.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.6.0-preview.19073.11" />
+    <PackageReference Include="System.Memory" Version="4.5.2" />
+    <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorSignalR/Internal/BlazorHttpConnection.cs
+++ b/src/BlazorSignalR/Internal/BlazorHttpConnection.cs
@@ -6,8 +6,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Blazor.Browser.Http;
-using Microsoft.AspNetCore.Blazor.Browser.Services;
+using Microsoft.AspNetCore.Blazor.Http;
+using Microsoft.AspNetCore.Blazor.Services;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.Connections.Features;
 using Microsoft.AspNetCore.Http.Connections;
@@ -111,7 +111,7 @@ namespace BlazorSignalR.Internal
             // Fix relative url paths
             if (!uri.IsAbsoluteUri || uri.Scheme == Uri.UriSchemeFile && uri.OriginalString.StartsWith("/", StringComparison.Ordinal))
             {
-                Uri baseUrl = new Uri(BrowserUriHelper.Instance.GetBaseUri());
+                Uri baseUrl = new Uri(WebAssemblyUriHelper.Instance.GetBaseUri());
                 uri = new Uri(baseUrl, uri);
             }
 
@@ -314,7 +314,7 @@ namespace BlazorSignalR.Internal
 
         private HttpClient CreateHttpClient()
         {
-            HttpMessageHandler handler = new BrowserHttpMessageHandler();
+            HttpMessageHandler handler = new WebAssemblyHttpMessageHandler();
             if (_options.HttpMessageHandlerFactory != null)
             {
                 handler = _options.HttpMessageHandlerFactory(handler);
@@ -327,7 +327,7 @@ namespace BlazorSignalR.Internal
             HttpClient httpClient =
                 new HttpClient(new LoggingHttpMessageHandler(handler, _loggerFactory))
                 {
-                    BaseAddress = new Uri(BrowserUriHelper.Instance.GetBaseUri()), Timeout = HttpClientTimeout
+                    BaseAddress = new Uri(WebAssemblyUriHelper.Instance.GetBaseUri()), Timeout = HttpClientTimeout
                 };
             //            httpClient.DefaultRequestHeaders.UserAgent.Add(Constants.UserAgentHeader);
             if (_options.Headers != null)

--- a/src/BlazorSignalR/Internal/StreamExtensions.cs
+++ b/src/BlazorSignalR/Internal/StreamExtensions.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Buffers;
-using System.Collections.Generic;
+﻿using System.Buffers;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
+++ b/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
@@ -1,14 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <RootNamespace>BlazorSignalR.Test.Client</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor.Extensions.Logging" Version="0.1.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Browser" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.7.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <!--<PackageReference Include="Blazor.Extensions.Logging" Version="0.1.9" />-->
+    <!-- This is not yet available for Blazor 0.8.0 https://github.com/BlazorExtensions/Logging/pull/22 -->
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.8.0-preview-19104-04" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.8.0-preview-19104-04" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Client/Pages/ChatComponent.cs
+++ b/test/BlazorSignalR.Test.Client/Pages/ChatComponent.cs
@@ -1,17 +1,16 @@
-using Blazor.Extensions.Logging;
-using Microsoft.AspNetCore.Blazor.Components;
-using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http.Connections;
+//using Blazor.Extensions.Logging;
+using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace BlazorSignalR.Test.Client.Pages
 {
-    public class ChatComponent : BlazorComponent
+    public class ChatComponent : ComponentBase
     {
         [Inject] private HttpClient _http { get; set; }
         [Inject] private ILogger<ChatComponent> _logger { get; set; }
@@ -32,7 +31,7 @@ namespace BlazorSignalR.Test.Client.Pages
             HubConnectionBuilder factory = new HubConnectionBuilder();
 
             factory.Services.AddLogging(builder => builder
-                .AddBrowserConsole() // Add Blazor.Extensions.Logging.BrowserConsoleLogger
+                //.AddBrowserConsole() // Add Blazor.Extensions.Logging.BrowserConsoleLogger // This is not yet available for Blazor 0.8.0 https://github.com/BlazorExtensions/Logging/pull/22
                 .SetMinimumLevel(LogLevel.Trace)
             );
 
@@ -92,7 +91,7 @@ namespace BlazorSignalR.Test.Client.Pages
 
         private void Handle(object msg)
         {
-            this._logger.LogInformation(msg);
+            this._logger.LogInformation(msg.ToString());
             this._messages.Add(msg.ToString());
             this.StateHasChanged();
         }

--- a/test/BlazorSignalR.Test.Client/Shared/MainLayout.cshtml
+++ b/test/BlazorSignalR.Test.Client/Shared/MainLayout.cshtml
@@ -1,4 +1,4 @@
-﻿@inherits BlazorLayoutComponent
+﻿@inherits LayoutComponentBase
 
 <div class="sidebar">
     <NavMenu />

--- a/test/BlazorSignalR.Test.Client/Startup.cs
+++ b/test/BlazorSignalR.Test.Client/Startup.cs
@@ -1,5 +1,4 @@
-using Blazor.Extensions.Logging;
-using Microsoft.AspNetCore.Blazor.Builder;
+using Microsoft.AspNetCore.Components.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace BlazorSignalR.Test.Client
@@ -8,10 +7,10 @@ namespace BlazorSignalR.Test.Client
     {
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddLogging(builder => builder.AddBrowserConsole());
+            services.AddLogging(/*builder => builder.AddBrowserConsole()*/); // This is not yet available for Blazor 0.8.0 https://github.com/BlazorExtensions/Logging/pull/22
         }
 
-        public void Configure(IBlazorApplicationBuilder app)
+        public void Configure(IComponentsApplicationBuilder app)
         {
             app.AddComponent<App>("app");
         }

--- a/test/BlazorSignalR.Test.Client/_ViewImports.cshtml
+++ b/test/BlazorSignalR.Test.Client/_ViewImports.cshtml
@@ -1,8 +1,8 @@
 @using System.Net.Http
 @using Microsoft.AspNetCore.Blazor
-@using Microsoft.AspNetCore.Blazor.Components
-@using Microsoft.AspNetCore.Blazor.Layouts
-@using Microsoft.AspNetCore.Blazor.Routing
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Layouts
+@using Microsoft.AspNetCore.Components.Routing
 @using BlazorSignalR.Test.Client
 @using BlazorSignalR.Test.Client.Shared
 @using BlazorSignalR

--- a/test/BlazorSignalR.Test.Client/wwwroot/index.html
+++ b/test/BlazorSignalR.Test.Client/wwwroot/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta charset="utf-8" />
@@ -11,6 +11,6 @@
 <body>
     <app>Loading...</app>
 
-    <script src="_framework/blazor.webassembly.js"></script>
+    <script src="_framework/components.webassembly.js"></script>
 </body>
 </html>

--- a/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
+++ b/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
@@ -1,14 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.7.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="1.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0-preview-19075-0444" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.8.0-preview-19104-04" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Server" Version="3.0.0-preview-19075-0444" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview-19075-0444" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.0.0-preview-19075-0444" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Server/Startup.cs
+++ b/test/BlazorSignalR.Test.Server/Startup.cs
@@ -3,19 +3,15 @@
 
 using BlazorSignalR.Test.Server.Hubs;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
-using Microsoft.AspNetCore.Blazor.Server;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Newtonsoft.Json.Serialization;
 using System;
 using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
-using System.Net.Mime;
 using System.Security.Claims;
 using System.Threading.Tasks;
 
@@ -34,7 +30,7 @@ namespace BlazorSignalR.Test.Server
             services
                 .AddSignalR(options => options.KeepAliveInterval = TimeSpan.FromSeconds(5))
 //                .AddMessagePackProtocol();
-                .AddJsonProtocol();
+                .AddNewtonsoftJsonProtocol();
 
             services.AddAuthorization(options =>
             {
@@ -81,7 +77,7 @@ namespace BlazorSignalR.Test.Server
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
-            services.AddMvc().AddJsonOptions(options =>
+            services.AddMvc().AddNewtonsoftJson(options =>
             {
                 options.SerializerSettings.ContractResolver = new DefaultContractResolver();
             });
@@ -95,14 +91,7 @@ namespace BlazorSignalR.Test.Server
                        .AllowCredentials();
             }));
 
-            services.AddResponseCompression(options =>
-            {
-                options.MimeTypes = ResponseCompressionDefaults.MimeTypes.Concat(new[]
-                {
-                    MediaTypeNames.Application.Octet,
-                    WasmMediaTypeNames.Application.Wasm,
-                });
-            });
+            services.AddResponseCompression();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
I migrated the project (including the sample projects) to Asp.Net Core 3.0 and Blazor 0.8.0 according to https://devblogs.microsoft.com/aspnet/blazor-0-8-0-experimental-release-now-available/ and https://docs.microsoft.com/en-us/aspnet/core/migration/22-to-30?view=aspnetcore-2.2&tabs=visual-studio.  

The dependency "Blazor.Extensions.Logging" is not yet ported to Blazor 0.8.0. I removed it. There is no client side logging in the sample project now. There is a open PR in the Blazor.Extensions.Logging repo that migrated the project. I added a comment at the places that need to be enabled again, when the pr is merged and available on nuget.

This fixes #5.