### PR TITLE
Update to Blazor 0.9.0

### DIFF
--- a/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
+++ b/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="3.0.0-preview-19075-0444" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Build" Version="3.0.0-preview3-19153-02" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/BlazorSignalR/BlazorSignalR.csproj
+++ b/src/BlazorSignalR/BlazorSignalR.csproj
@@ -10,18 +10,15 @@
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2POutput</TargetsForTfmSpecificBuildOutput>
     <Version>0.4.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <BlazorLinkOnBuild>false</BlazorLinkOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.8.0-preview-19104-04" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="3.0.0-preview-19075-0444" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0-preview-19075-0444" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0-preview.19074.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.9.0-preview3-19154-02" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Browser" Version="3.0.0-preview3-19153-02" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0-preview3-19153-02" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0-preview3.19153.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.6.0-preview.19073.11" />
-    <PackageReference Include="System.Memory" Version="4.5.2" />
-    <PackageReference Include="System.Threading.Channels" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BlazorSignalR/BlazorSignalRExtensions.cs
+++ b/src/BlazorSignalR/BlazorSignalRExtensions.cs
@@ -3,22 +3,27 @@ using BlazorSignalR.Internal;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
 
 namespace BlazorSignalR
 {
     public static class BlazorSignalRExtensions
     {
-        public static IHubConnectionBuilder WithUrlBlazor(this IHubConnectionBuilder hubConnectionBuilder, string url,
+        public static IHubConnectionBuilder WithUrlBlazor(this IHubConnectionBuilder hubConnectionBuilder, string url, IJSRuntime jsRuntime,
             HttpTransportType? transports = null, Action<BlazorHttpConnectionOptions> options = null)
         {
-            return WithUrlBlazor(hubConnectionBuilder, new Uri(url), transports, options);
+            return WithUrlBlazor(hubConnectionBuilder, new Uri(url), jsRuntime, transports, options);
         }
 
-        public static IHubConnectionBuilder WithUrlBlazor(this IHubConnectionBuilder hubConnectionBuilder, Uri url,
+        public static IHubConnectionBuilder WithUrlBlazor(this IHubConnectionBuilder hubConnectionBuilder, Uri url, IJSRuntime jsRuntime,
             HttpTransportType? transports = null, Action<BlazorHttpConnectionOptions> options = null)
         {
             if (hubConnectionBuilder == null)
                 throw new ArgumentNullException(nameof(hubConnectionBuilder));
+
+            if (jsRuntime == null)
+                throw new ArgumentNullException(nameof(jsRuntime));
+
             hubConnectionBuilder.Services.Configure<BlazorHttpConnectionOptions>(o =>
             {
                 o.Url = url;
@@ -28,8 +33,15 @@ namespace BlazorSignalR
             });
             if (options != null)
                 hubConnectionBuilder.Services.Configure(options);
-            hubConnectionBuilder.Services.AddSingleton<IConnectionFactory, BlazorHttpConnectionFactory>();
+            hubConnectionBuilder.Services.AddSingleton(provider => BuildBlazorHttpConnectionFactory(provider, jsRuntime));
             return hubConnectionBuilder;
+        }
+
+        private static IConnectionFactory BuildBlazorHttpConnectionFactory(IServiceProvider provider, IJSRuntime jsRuntime)
+        {
+            return ActivatorUtilities.CreateInstance<BlazorHttpConnectionFactory>(
+                provider,
+                jsRuntime as IJSInProcessRuntime ?? new JSRuntimeWrapper(jsRuntime));
         }
     }
 }

--- a/src/BlazorSignalR/Internal/BlazorHttpConnectionFactory.cs
+++ b/src/BlazorSignalR/Internal/BlazorHttpConnectionFactory.cs
@@ -1,27 +1,34 @@
-﻿using System.Threading;
+﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.JSInterop;
 
 namespace BlazorSignalR.Internal
 {
     internal class BlazorHttpConnectionFactory : IConnectionFactory
     {
         private readonly BlazorHttpConnectionOptions _options;
+        private readonly IJSInProcessRuntime _jsRuntime;
         private readonly ILoggerFactory _loggerFactory;
 
-        public BlazorHttpConnectionFactory(IOptions<BlazorHttpConnectionOptions> options, ILoggerFactory loggerFactory)
+        public BlazorHttpConnectionFactory(IOptions<BlazorHttpConnectionOptions> options, IJSInProcessRuntime jsRuntime, ILoggerFactory loggerFactory)
         {
+            if (jsRuntime == null)
+                throw new ArgumentNullException(nameof(jsRuntime));
+
             _options = options.Value;
+            _jsRuntime = jsRuntime;
             _loggerFactory = loggerFactory;
         }
 
         public async Task<ConnectionContext> ConnectAsync(TransferFormat transferFormat,
             CancellationToken cancellationToken = new CancellationToken())
         {
-            BlazorHttpConnection connection = new BlazorHttpConnection(_options, _loggerFactory);
+            BlazorHttpConnection connection = new BlazorHttpConnection(_options, _jsRuntime, _loggerFactory);
 
             try
             {
@@ -37,7 +44,7 @@ namespace BlazorSignalR.Internal
 
         public Task DisposeAsync(ConnectionContext connection)
         {
-            return ((BlazorHttpConnection) connection).DisposeAsync();
+            return ((BlazorHttpConnection)connection).DisposeAsync();
         }
     }
 }

--- a/src/BlazorSignalR/Internal/BlazorWebSocketsTransport.cs
+++ b/src/BlazorSignalR/Internal/BlazorWebSocketsTransport.cs
@@ -1,15 +1,10 @@
 ﻿using System;
 using System.Buffers;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Net.WebSockets;
-using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Connections;
-using Microsoft.AspNetCore.Http.Connections.Client;
 using Microsoft.AspNetCore.Http.Connections.Client.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -21,6 +16,7 @@ namespace BlazorSignalR.Internal
     {
         private IDuplexPipe _application;
         private readonly ILogger _logger;
+        private readonly IJSInProcessRuntime _jSRuntime;
         private volatile bool _aborted;
 
         private IDuplexPipe _transport;
@@ -38,11 +34,15 @@ namespace BlazorSignalR.Internal
         private TaskCompletionSource<object> _startTask;
         private TaskCompletionSource<object> _receiveTask;
 
-        public BlazorWebSocketsTransport(string token, ILoggerFactory loggerFactory)
+        public BlazorWebSocketsTransport(string token, IJSInProcessRuntime jSRuntime, ILoggerFactory loggerFactory)
         {
+            if (jSRuntime == null)
+                throw new ArgumentNullException(nameof(jSRuntime));
+
             _logger = (loggerFactory ?? NullLoggerFactory.Instance).CreateLogger<BlazorWebSocketsTransport>();
             InternalWebSocketId = Guid.NewGuid().ToString();
             WebSocketAccessToken = token;
+            _jSRuntime = jSRuntime;
         }
 
         public async Task StartAsync(Uri url, TransferFormat transferFormat)
@@ -64,7 +64,7 @@ namespace BlazorSignalR.Internal
 
             // Create connection
             _startTask = new TaskCompletionSource<object>();
-            ((IJSInProcessRuntime) JSRuntime.Current).Invoke<object>(
+            _jSRuntime.Invoke<object>(
                 "BlazorSignalR.WebSocketsTransport.CreateConnection", url.ToString(),
                 transferFormat == TransferFormat.Binary, new DotNetObjectRef(this));
 
@@ -222,7 +222,7 @@ namespace BlazorSignalR.Internal
 
                                 Log.SendStarted(_logger);
 
-                                ((IJSInProcessRuntime) JSRuntime.Current).Invoke<object>(
+                                _jSRuntime.Invoke<object>(
                                     "BlazorSignalR.WebSocketsTransport.Send", data, new DotNetObjectRef(this));
                             }
                             catch (Exception ex)
@@ -301,7 +301,7 @@ namespace BlazorSignalR.Internal
             Log.ClosingWebSocket(_logger);
             try
             {
-                ((IJSInProcessRuntime) JSRuntime.Current).Invoke<object>(
+                _jSRuntime.Invoke<object>(
                     "BlazorSignalR.WebSocketsTransport.CloseConnection", new DotNetObjectRef(this));
             }
             catch (Exception e)
@@ -333,9 +333,12 @@ namespace BlazorSignalR.Internal
             _receiveTask?.SetCanceled();
         }
 
-        public static bool IsSupported()
+        public static bool IsSupported(IJSInProcessRuntime jsRuntime)
         {
-            return ((IJSInProcessRuntime) JSRuntime.Current).Invoke<bool>(
+            if (jsRuntime == null)
+                throw new ArgumentNullException(nameof(jsRuntime));
+
+            return jsRuntime.Invoke<bool>(
                 "BlazorSignalR.WebSocketsTransport.IsSupported");
         }
 

--- a/src/BlazorSignalR/Internal/JSRuntimeWrapper.cs
+++ b/src/BlazorSignalR/Internal/JSRuntimeWrapper.cs
@@ -1,0 +1,31 @@
+﻿using System.Threading.Tasks;
+using Microsoft.JSInterop;
+
+namespace BlazorSignalR.Internal
+{
+    internal sealed class JSRuntimeWrapper : IJSInProcessRuntime
+    {
+        private readonly IJSRuntime _jsRuntime;
+
+        public JSRuntimeWrapper(IJSRuntime jsRuntime)
+        {
+            _jsRuntime = jsRuntime;
+        }
+
+        public T Invoke<T>(string identifier, params object[] args)
+        {
+            var task = _jsRuntime.InvokeAsync<T>(identifier, args);
+            return task.ConfigureAwait(false).GetAwaiter().GetResult();
+        }
+
+        public Task<T> InvokeAsync<T>(string identifier, params object[] args)
+        {
+            return _jsRuntime.InvokeAsync<T>(identifier, args);
+        }
+
+        public void UntrackObjectRef(DotNetObjectRef dotNetObjectRef)
+        {
+            _jsRuntime.UntrackObjectRef(dotNetObjectRef);
+        }
+    }
+}

--- a/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
+++ b/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
@@ -7,14 +7,17 @@
   <ItemGroup>
     <!--<PackageReference Include="Blazor.Extensions.Logging" Version="0.1.9" />-->
     <!-- This is not yet available for Blazor 0.8.0 https://github.com/BlazorExtensions/Logging/pull/22 -->
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.8.0-preview-19104-04" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.8.0-preview-19104-04" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="0.9.0-preview3-19154-02" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="0.9.0-preview3-19154-02" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\BlazorSignalR.JS\BlazorSignalR.JS.csproj" />
     <ProjectReference Include="..\..\src\BlazorSignalR\BlazorSignalR.csproj" />
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Copy SourceFiles="$(TargetDir)\System.Memory.dll" DestinationFolder="$(TargetDir)dist\_framework\_bin\"/>
+  </Target>
 
 </Project>

--- a/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
+++ b/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
@@ -16,6 +16,7 @@
     <ProjectReference Include="..\..\src\BlazorSignalR\BlazorSignalR.csproj" />
   </ItemGroup>
 
+  <!-- See: https://github.com/aspnet/AspNetCore/issues/8414 -->
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Copy SourceFiles="$(TargetDir)\System.Memory.dll" DestinationFolder="$(TargetDir)dist\_framework\_bin\"/>
   </Target>

--- a/test/BlazorSignalR.Test.Client/Pages/ChatComponent.cs
+++ b/test/BlazorSignalR.Test.Client/Pages/ChatComponent.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.JSInterop;
 
 namespace BlazorSignalR.Test.Client.Pages
 {
@@ -14,6 +15,7 @@ namespace BlazorSignalR.Test.Client.Pages
     {
         [Inject] private HttpClient _http { get; set; }
         [Inject] private ILogger<ChatComponent> _logger { get; set; }
+        [Inject] private IJSRuntime _jsRuntime { get; set; }
         internal string _toEverybody { get; set; }
         internal string _toConnection { get; set; }
         internal string _connectionId { get; set; }
@@ -35,7 +37,7 @@ namespace BlazorSignalR.Test.Client.Pages
                 .SetMinimumLevel(LogLevel.Trace)
             );
 
-            factory.WithUrlBlazor("/chathub", options: opt =>
+            factory.WithUrlBlazor("/chathub", _jsRuntime, options: opt =>
             {
 //                opt.Transports = HttpTransportType.WebSockets;
 //                opt.SkipNegotiation = true;

--- a/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
+++ b/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0-preview-19075-0444" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.8.0-preview-19104-04" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.Server" Version="3.0.0-preview-19075-0444" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview-19075-0444" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0-preview3-19153-02" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="0.9.0-preview3-19154-02" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Server" Version="3.0.0-preview3-19153-02" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview3-19153-02" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.0.0-preview-19075-0444" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.0.0-preview3-19153-02" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Server/Startup.cs
+++ b/test/BlazorSignalR.Test.Server/Startup.cs
@@ -82,19 +82,11 @@ namespace BlazorSignalR.Test.Server
                 options.SerializerSettings.ContractResolver = new DefaultContractResolver();
             });
 
-            services.AddCors(options => options.AddPolicy("CorsPolicy",
-            builder =>
-            {
-                builder.AllowAnyMethod()
-                       .AllowAnyHeader()
-                       .AllowAnyOrigin()
-                       .AllowCredentials();
-            }));
-
             services.AddResponseCompression();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        [Obsolete] // IHostingEnvironment is obsolete. Maybe the sample should be updated.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
             app.UseResponseCompression();


### PR DESCRIPTION
I updated the library and the sample to `Blazor 0.9.0`.

There seems to be a bug with blazor/mono and some assemblies. This is the case for `System.Memory` here. I had to insert a post build event to customly copy some files. This is a dirty workaround and should be removed when this is fixed. I openend an issue for this: https://github.com/aspnet/AspNetCore/issues/8414

I had to modify the public API of the HubConnectionBuilder extension to accept the js runtime as we do not have a static accessor for this any more. **This is a breaking change.** 
See:   
https://github.com/AndreasTruetschel/BlazorSignalR/commit/f64d34084a9e8ec6348adb0a9b358268c23171e9#diff-e9d9f06e9f712c28b10b1d87b7ae90b9  
https://github.com/AndreasTruetschel/BlazorSignalR/commit/f64d34084a9e8ec6348adb0a9b358268c23171e9#diff-1153528322b2944586221c4ce623072e

Closes #7 