### PR TITLE
Update to 3.1.0-preview1

### DIFF
--- a/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
+++ b/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview9.19424.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview1.19508.20" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/BlazorSignalR/BlazorSignalR.csproj
+++ b/src/BlazorSignalR/BlazorSignalR.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19424.4" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.0.0-preview9.19424.4" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.0-preview9.19423.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0-preview1.19506.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
+++ b/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
@@ -7,10 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="Blazor.Extensions.Logging" Version="0.1.9" />-->
-    <!-- This is not yet available for Blazor 0.8.0 https://github.com/BlazorExtensions/Logging/pull/22 -->
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.0.0-preview9.19424.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.0.0-preview9.19424.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview1.19508.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Client/DemoData.cs
+++ b/test/BlazorSignalR.Test.Client/DemoData.cs
@@ -1,8 +1,13 @@
+using System;
+
 namespace BlazorSignalR.Test.Client
 {
     public class DemoData
     {
         public int Id { get; set; }
+        public decimal Decimal { get; set; }
         public string Data { get; set; }
+        public DateTime DateTime { get; set; }
+        public bool Bool { get; set; }
     }
 }

--- a/test/BlazorSignalR.Test.Client/Pages/ChatComponent.cs
+++ b/test/BlazorSignalR.Test.Client/Pages/ChatComponent.cs
@@ -106,7 +106,23 @@ namespace BlazorSignalR.Test.Client.Pages
 
         private void Handle(object msg)
         {
-            this.Logger.LogInformation(msg.ToString());
+            if(msg is DemoData)
+            {
+                var demoData = msg as DemoData;
+                this.Messages.Add($"demoData.id({demoData.Id}) | demoData.Data({demoData.Data}) | demoData.DateTime({demoData.DateTime}) | demoData.Decimal({demoData.Decimal}) | demoData.Bool({demoData.Bool})");
+            }
+            else if(msg is DemoData[])
+            {
+                var demoDatas = msg as DemoData[];
+                foreach (var demoData in demoDatas)
+                {
+                    this.Messages.Add($"demoData.id({demoData.Id}) | demoData.Data({demoData.Data}) | demoData.DateTime({demoData.DateTime}) | demoData.Decimal({demoData.Decimal}) | demoData.Bool({demoData.Bool})");
+                }
+            }
+            else
+            {
+                this.Logger.LogInformation(msg.ToString());
+            }
             this.Messages.Add(msg.ToString());
             this.StateHasChanged();
         }

--- a/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
+++ b/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.0.0-preview9.19424.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.0.0-preview9.19424.4" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0-preview9.19424.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0-preview1.19508.20" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.0.0-preview9.19424.4" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.0-preview1.19508.20" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Server/Hubs/ChatHub.cs
+++ b/test/BlazorSignalR.Test.Server/Hubs/ChatHub.cs
@@ -13,9 +13,9 @@ namespace BlazorSignalR.Test.Server.Hubs
     {
         public async Task DoSomething()
         {
-            await this.Clients.All.SendAsync("DemoMethodObject", new DemoData {Id = 1, Data = "Demo Data"});
+            await this.Clients.All.SendAsync("DemoMethodObject", new DemoData {Id = 1, Data = "Demo Data", Decimal = 0.000000001M, DateTime = DateTime.UtcNow, Bool = true });
             await this.Clients.All.SendAsync("DemoMethodList",
-                Enumerable.Range(1, 10).Select(x => new DemoData {Id = x, Data = $"Demo Data #{x}"}).ToList());
+                Enumerable.Range(1, 10).Select(x => new DemoData {Id = x, Data = $"Demo Data #{x}", Decimal = x * 0.000000001M, DateTime = DateTime.UtcNow.AddSeconds(-x), Bool = (x % 2 == 0) }).ToList());
         }
 
 


### PR DESCRIPTION
Hi there, great library thanks!

I have upgraded to `3.1.0-preview1` without issues.

I have also added through some additional testing cover.  This was due to me spending time getting to the bottom of https://github.com/BlazorExtensions/SignalR/pull/58 .

The additional cover is basically a deserialisation sanity test which was failing with BlazorExtension's lib.

So thanks again!