### PR TITLE
Update to blazor 3.1.0 preview 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BlazorSignalR ![Blazor=3.1.0-preview1](https://img.shields.io/badge/Blazor-3.1.0--preview1-informational.svg) [![NuGet=BlazorSignalR](https://img.shields.io/badge/NuGet-BlazorSignalR-informational.svg)](https://www.nuget.org/packages/BlazorSignalR)
+# BlazorSignalR ![Blazor=3.1.0-preview3](https://img.shields.io/badge/Blazor-3.1.0--preview3-informational.svg) [![NuGet=BlazorSignalR](https://img.shields.io/badge/NuGet-BlazorSignalR-informational.svg)](https://www.nuget.org/packages/BlazorSignalR)
 This package is a compatibility library for [Microsoft ASP.NET Core SignalR](https://github.com/aspnet/SignalR) to allow it to run on [Microsoft ASP.NET Blazor](https://github.com/aspnet/Blazor).
 
 The package is an addon for the existing .net client for SingalR, this is unlike the ```BlazorExtensions/SignalR``` package which emulates the c# api. This package instead works by replacing the transport mechanics, meaning the front facing SignalR api is still the standard .net one. The benefits of this setup is that as SignalR changes, this package takes little maintenance, as it only replaces the transport mechanisms, which are unlikely to change.
@@ -52,6 +52,7 @@ JS implemented means that the network requests are proxied to and from Javascrip
 ## Versions
 | Blazor         | BlazorSignalR |
 | --------------:| -------------:|
+| 3.1.0-preview3 |     0.12.x    |
 | 3.1.0-preview1 |     0.11.x    |
 | 3.0.0-preview9 |     0.10.x    |
 | 3.0.0-preview8 |     0.9.x     |

--- a/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
+++ b/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
@@ -11,12 +11,12 @@
 
     <!-- VS's FastUpToDateCheck doesn't consider .ts file changes, so it's necessary to disable it to get incremental builds to work correctly (albeit not as fast as if FastUpToDateCheck did work for them) -->
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
-    <Version>0.11.0-blazor-3.1.0-preview1.19508.20</Version>
+    <Version>0.12.0-blazor-3.1.0-preview3.19555.2</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview3.19555.2" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/BlazorSignalR/BlazorSignalR.csproj
+++ b/src/BlazorSignalR/BlazorSignalR.csproj
@@ -8,14 +8,14 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2POutput</TargetsForTfmSpecificBuildOutput>
-    <Version>0.11.0-blazor-3.1.0-preview1.19508.20</Version>
+    <Version>0.12.0-blazor-3.1.0-preview3.19555.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview1.19508.20" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0-preview1.19508.20" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0-preview1.19506.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0-preview3.19553.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
+++ b/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview1.19508.20" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview3.19555.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
+++ b/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0-preview1.19508.20" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview1.19508.20" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0-preview3.19555.2" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.0-preview1.19508.20" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.0-preview3.19555.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Update to blazor 3.1.0 preview 3

Updated the references for 3.1.0 preview 3.

Please review `BlazorHttpConnection.cs` the type `WebAssemblyHttpMessageHandler` is not available anymore. I looked at how blazor is getting this type now see here:

https://github.com/aspnet/AspNetCore/blob/e683b087c5c395bfa279940aadd3ee8b57b7d886/src/Components/Blazor/Blazor/src/Http/WebAssemblyHttpMessageHandlerOptions.cs#L37

I think my fix is the closest we can get at the moment. It might break in a future version without creating a build error though.