### PR TITLE
Upgrade to preview 4

### DIFF
--- a/BlazorSignalR.sln
+++ b/BlazorSignalR.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29521.150
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B286BCBD-DAD8-4DE7-9334-3DE18DF233AF}"
 EndProject
@@ -11,6 +11,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlazorSignalR", "src\Blazor
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8A34FDEB-D488-4AE3-887B-8254B33C7A13}"
 	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Directory.Build.targets = Directory.Build.targets
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,8 +24,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <TestProjectTargetFramework>netstandard2.0</TestProjectTargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <TestProjectTargetFramework>netstandard2.1</TestProjectTargetFramework>
   </PropertyGroup>
 
   <!-- Versioning properties -->

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# BlazorSignalR ![Blazor=3.1.0-preview3](https://img.shields.io/badge/Blazor-3.1.0--preview3-informational.svg) [![NuGet=BlazorSignalR](https://img.shields.io/badge/NuGet-BlazorSignalR-informational.svg)](https://www.nuget.org/packages/BlazorSignalR)
+# BlazorSignalR ![Blazor=3.1.0-preview4](https://img.shields.io/badge/Blazor-3.1.0--preview4-informational.svg) [![NuGet=BlazorSignalR](https://img.shields.io/badge/NuGet-BlazorSignalR-informational.svg)](https://www.nuget.org/packages/BlazorSignalR)
 This package is a compatibility library for [Microsoft ASP.NET Core SignalR](https://github.com/aspnet/SignalR) to allow it to run on [Microsoft ASP.NET Blazor](https://github.com/aspnet/Blazor).
 
 The package is an addon for the existing .net client for SingalR, this is unlike the ```BlazorExtensions/SignalR``` package which emulates the c# api. This package instead works by replacing the transport mechanics, meaning the front facing SignalR api is still the standard .net one. The benefits of this setup is that as SignalR changes, this package takes little maintenance, as it only replaces the transport mechanisms, which are unlikely to change.
@@ -52,6 +52,7 @@ JS implemented means that the network requests are proxied to and from Javascrip
 ## Versions
 | Blazor         | BlazorSignalR |
 | --------------:| -------------:|
+| 3.1.0-preview4 |     0.13.x    |
 | 3.1.0-preview3 |     0.12.x    |
 | 3.1.0-preview1 |     0.11.x    |
 | 3.0.0-preview9 |     0.10.x    |

--- a/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
+++ b/src/BlazorSignalR.JS/BlazorSignalR.JS.csproj
@@ -11,12 +11,12 @@
 
     <!-- VS's FastUpToDateCheck doesn't consider .ts file changes, so it's necessary to disable it to get incremental builds to work correctly (albeit not as fast as if FastUpToDateCheck did work for them) -->
     <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
-    <Version>0.12.0-blazor-3.1.0-preview3.19555.2</Version>
+    <Version>0.13.0-blazor-3.1.0-preview4.19579.2</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview4.19579.2" />
     <WebpackInputs Include="**\*.ts" Exclude="dist\**;node_modules\**" />
   </ItemGroup>
 

--- a/src/BlazorSignalR/BlazorSignalR.csproj
+++ b/src/BlazorSignalR/BlazorSignalR.csproj
@@ -8,14 +8,14 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);IncludeP2POutput</TargetsForTfmSpecificBuildOutput>
-    <Version>0.12.0-blazor-3.1.0-preview3.19555.2</Version>
+    <Version>0.13.0-blazor-3.1.0-preview4.19579.2</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview3.19555.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0-preview3.19555.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0-preview3.19553.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview4.19579.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
+++ b/test/BlazorSignalR.Test.Client/BlazorSignalR.Test.Client.csproj
@@ -1,14 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <RootNamespace>BlazorSignalR.Test.Client</RootNamespace>
-    <LangVersion>8.0</LangVersion> <!-- We need this, as the razor engine will use C# 8 features.-->
+    <LangVersion>8.0</LangVersion>
+    <!-- We need this, as the razor engine will use C# 8 features.-->
     <RazorLangVersion>3.0</RazorLangVersion>
+    <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview3.19555.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor" Version="3.1.0-preview4.19579.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Build" Version="3.1.0-preview4.19579.2" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/BlazorSignalR.Test.Client/_Imports.razor
+++ b/test/BlazorSignalR.Test.Client/_Imports.razor
@@ -1,4 +1,5 @@
 @using System.Net.Http
+@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Blazor
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Forms
@@ -7,4 +8,6 @@
 @using BlazorSignalR.Test.Client
 @using BlazorSignalR.Test.Client.Shared
 @using BlazorSignalR
+@using Microsoft.JSInterop
+
 @*@using Blazor.Extensions*@

--- a/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
+++ b/test/BlazorSignalR.Test.Server/BlazorSignalR.Test.Server.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0-preview3.19555.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview3.19555.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Blazor.Server" Version="3.1.0-preview4.19579.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.0-preview3.19555.2" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrade to preview 4, which should be similar to last upgrade, but for some reason I am seeing an error in the console when I run the project and I have not managed to solve it.

Basically, the error appears when the client (wasm) project is changed from target framework netstandard20 to netstandard2.1. However I know the client can be upgraded to netstandard2.1 work under dotnet code sdk 3.1.0 because this is what I do in a seperate blazor client which is working fine. I couldn't see any obvious differences though.

I would appreciate if someone could review this PR, and let me know if they experience the same problem when running the project.
